### PR TITLE
Fix command injection risk in openBrowser

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -49,6 +49,17 @@ function clearCredentials() {
 }
 
 function openBrowser(url) {
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      console.warn('Failed to open browser: Invalid URL protocol');
+      return;
+    }
+  } catch {
+    console.warn('Failed to open browser: Invalid URL');
+    return;
+  }
   const onError = (err) => {
     if (err) console.warn('Failed to open browser:', err.message);
   };


### PR DESCRIPTION
Fixed a potential command injection vulnerability in src/lib/auth.js within the openBrowser function. Added a try-catch block to parse the provided url and verify that the protocol is exactly 'http:' or 'https:' before executing any commands to open it.
If left unfixed, execFile could potentially be exploited by passing a malicious URL or a URL with a dangerous protocol scheme (e.g., file://, javascript:, or specific shell-executable patterns), which could lead to arbitrary command execution on the user's machine (Windows explorer.exe, macOS open, or Linux xdg-open).

The fix uses the native JavaScript URL constructor to safely parse the provided URL string before attempting to open it in the browser. If parsing throws an error, or if the parsed URL’s protocol is anything other than http: or https:, the function immediately logs a warning with console.warn and returns early. This prevents invalid or unsupported URLs from being passed to execFile, reducing the risk of unexpected behavior and ensuring that no child process is launched unless the URL is well-formed and uses an allowed web protocol.