### PR TITLE
fix: bump plugin.json version to 0.0.3 to match marketplace.json

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-supermemory",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Persistent memory across Claude Code sessions using Supermemory",
   "author": {
     "name": "Supermemory",


### PR DESCRIPTION
The previous version bump updated `.claude-plugin/marketplace.json` to 0.0.3 but left `plugin/.claude-plugin/plugin.json` at 0.0.2. 

Claude Code reads plugin.json to decide whether an update is available, so users on 0.0.2 are told they are already current and never receive the update.

Fixes #43