### PR TITLE
Fix Windows auth URL opener

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -2,7 +2,7 @@ const http = require('node:http');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { execFile } = require('node:child_process');
+const { openUrl } = require('./open-url');
 
 const authSuccessHtml = require('../templates/auth-success.html');
 const authErrorHtml = require('../templates/auth-error.html');
@@ -48,19 +48,6 @@ function clearCredentials() {
   } catch {}
 }
 
-function openBrowser(url) {
-  const onError = (err) => {
-    if (err) console.warn('Failed to open browser:', err.message);
-  };
-  if (process.platform === 'win32') {
-    execFile('explorer.exe', [url], onError);
-  } else if (process.platform === 'darwin') {
-    execFile('open', [url], onError);
-  } else {
-    execFile('xdg-open', [url], onError);
-  }
-}
-
 function startAuthFlow() {
   return new Promise((resolve, reject) => {
     let resolved = false;
@@ -92,7 +79,12 @@ function startAuthFlow() {
     server.listen(AUTH_PORT, '127.0.0.1', () => {
       const callbackUrl = `http://localhost:${AUTH_PORT}/callback`;
       const authUrl = `${AUTH_BASE_URL}?callback=${encodeURIComponent(callbackUrl)}&client=claude_code`;
-      openBrowser(authUrl);
+      openUrl(authUrl).catch((error) => {
+        if (!resolved) {
+          server.close();
+          reject(new Error(`Failed to open browser: ${error.message}`));
+        }
+      });
     });
 
     server.on('error', (err) => {

--- a/src/lib/open-url.js
+++ b/src/lib/open-url.js
@@ -1,0 +1,36 @@
+const { execFile } = require('node:child_process');
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { windowsHide: true }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function openUrl(url) {
+  const href = url.toString();
+  if (!/^https?:\/\//i.test(href)) {
+    throw new Error('Refusing to open non-http URL');
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      await run('rundll32.exe', ['url.dll,FileProtocolHandler', href]);
+      return;
+    } catch {}
+
+    await run('cmd.exe', ['/c', 'start', '""', href]);
+    return;
+  }
+
+  if (process.platform === 'darwin') {
+    await run('open', [href]);
+    return;
+  }
+
+  await run('xdg-open', [href]);
+}
+
+module.exports = { openUrl };


### PR DESCRIPTION
## What changed
- Replaced the Claude Code auth flow's Windows explorer.exe launcher with a guarded openUrl helper.
- Windows now uses rundll32.exe url.dll,FileProtocolHandler first, with cmd /c start fallback.
- Auth now rejects clearly if browser launch fails instead of silently continuing.
- Rebuilt committed plugin scripts so bundled plugin artifacts include the safe opener.

## Why
On Windows, launching OAuth URLs through explorer.exe can reinterpret long auth URLs as filesystem targets and redirect users into local/internal paths instead of the browser OAuth flow.