### PR TITLE
Fix update path for users on the old claude-supermemory plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ Your agent remembers what you worked on - across sessions, across projects.
 > **Already have the old `claude-supermemory` plugin installed?** It was renamed to `supermemory`, so it won't update in place. Migrate with:
 >
 > ```bash
-> /plugin uninstall claude-supermemory@supermemory-plugins
 > /plugin marketplace update supermemory-plugins
 > /plugin install supermemory@supermemory-plugins
+> ```
+>
+> Then, **only if you still have the old plugin**, remove it:
+>
+> ```bash
+> /plugin uninstall claude-supermemory@supermemory-plugins
 > ```
 
 Set your API key (get one at [app.supermemory.ai](https://app.supermemory.ai)):

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Your agent remembers what you worked on - across sessions, across projects.
 /plugin install supermemory
 ```
 
+> **Already have the old `claude-supermemory` plugin installed?** It was renamed to `supermemory`, so it won't update in place. Migrate with:
+>
+> ```bash
+> /plugin uninstall claude-supermemory@supermemory-plugins
+> /plugin marketplace update supermemory-plugins
+> /plugin install supermemory@supermemory-plugins
+> ```
+
 Set your API key (get one at [app.supermemory.ai](https://app.supermemory.ai)):
 
 ```bash

--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
   "version": "0.0.7",
-  "updateCommand": "/plugin uninstall claude-supermemory@supermemory-plugins\n/plugin marketplace update supermemory-plugins\n/plugin install supermemory@supermemory-plugins"
+  "updateCommand": "/plugin marketplace update supermemory-plugins\n/plugin install supermemory@supermemory-plugins\n\nOnly if you still have the old \"claude-supermemory\" plugin, also remove it:\n/plugin uninstall claude-supermemory@supermemory-plugins"
 }

--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
   "version": "0.0.7",
-  "updateCommand": "/plugin marketplace add supermemoryai/claude-supermemory && /plugin install supermemory"
+  "updateCommand": "/plugin uninstall claude-supermemory@supermemory-plugins\n/plugin marketplace update supermemory-plugins\n/plugin install supermemory@supermemory-plugins"
 }


### PR DESCRIPTION
## Problem

Renaming the plugin from `claude-supermemory` to `supermemory` (#60) orphaned existing installs. Claude Code keys an installed plugin by its `name` in `marketplace.json`, and there is **no in-place rename/migration** — so `/plugin marketplace update` can't carry old users over to the new name.

The only channel that still reaches those users is their **already-installed hook**, which fetches `latest.json` from `main` each session and prints its `updateCommand`. That command was wrong for a rename:

```
/plugin marketplace add supermemoryai/claude-supermemory && /plugin install supermemory
```

- It relies on `&&`-chaining, which Claude Code slash commands **don't support**.
- It only *installs* `supermemory` without removing the old `claude-supermemory`, leaving a duplicate that keeps showing the "update available" notice forever.

## Fix

Rewrite `latest.json`'s `updateCommand` to the documented migration (one command per line, no `&&`):

```
/plugin uninstall claude-supermemory@supermemory-plugins
/plugin marketplace update supermemory-plugins
/plugin install supermemory@supermemory-plugins
```

Also add the same steps to the README for anyone who has the old plugin installed.

## Why this is safe and complete

- **Reaches every affected user:** all old installs are below `0.0.7`, so they still trigger the update notice — now with the correct migration.
- **Ends the nag cleanly:** after migrating, users are on `supermemory@0.0.7`, which matches `latest.json`, so the notice stops and the orphaned old plugin is removed.
- **No one new is orphaned:** fresh `supermemory@0.0.7` installs see no notice.
- **No version churn / no rebuild:** `latest.json` is fetched live from `main` (not bundled), version stays `0.0.7`, and only `latest.json` + `README.md` change. Lint passes.

The "keep both marketplace entries as an alias" approach was rejected — two entries sharing one `source`, and a marketplace-entry name differing from `plugin.json`'s name, are both undocumented behaviors in Claude Code. This migration-command path is the documented one.

Requested via Slack: https://supermemory-ai.slack.com/archives/C0AAB6D3DD4/p1781162685552889

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01424Bk69KXtjWYvnueZJJad)_