### PR TITLE
Polish plugin manifest for official marketplace listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "supermemory-plugins",
+  "description": "Supermemory plugins for Claude Code — persistent memory across sessions and projects",
   "owner": {
     "name": "Supermemory",
     "email": "support@supermemory.ai"
@@ -9,7 +10,7 @@
       "name": "supermemory",
       "source": "./plugin",
       "description": "Persistent memory across Claude Code sessions using Supermemory",
-      "version": "0.0.7",
+      "category": "productivity",
       "author": {
         "name": "Supermemory"
       }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Your agent remembers what you worked on - across sessions, across projects.
 
 ## Installation
 
+> **Requires Node.js 18+** on your PATH — the memory hooks run as Node scripts.
+
 ```bash
 /plugin marketplace add supermemoryai/claude-supermemory
 /plugin install supermemory

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,9 +1,14 @@
 {
   "name": "supermemory",
+  "displayName": "Supermemory",
   "version": "0.0.7",
   "description": "Persistent memory across Claude Code sessions using Supermemory",
   "author": {
     "name": "Supermemory",
     "email": "support@supermemory.ai"
-  }
+  },
+  "homepage": "https://supermemory.ai",
+  "repository": "https://github.com/supermemoryai/claude-supermemory",
+  "license": "MIT",
+  "keywords": ["claude-code", "plugin", "supermemory", "memory", "ai", "context"]
 }


### PR DESCRIPTION
Prep the supermemory plugin for an official Claude Code marketplace listing.

- Enrich `plugin.json`: `displayName`, `homepage`, `repository`, `license`, `keywords`
- Move `category` to the marketplace entry and drop the duplicate `version` (plugin.json is now the sole authority)
- Add a top-level marketplace `description`
- Note the Node.js 18+ runtime requirement in the README