### PR TITLE
feat: reasoned per-turn memory recall with auto-approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ export SUPERMEMORY_CC_API_KEY="sm_..."
 
 ## How It Works
 
+- **Reasoned recall** — Before each turn, Claude decides whether recalling memory would actually help your current message, and only searches when it's worth it — every turn, once in a while, or not at all. The search runs automatically (no permission prompt), just like auto-capture. Searching only when needed also keeps more usage on your plan
 - **supermemory-search** — Ask about past work or previous sessions, Claude searches your memories
 - **supermemory-save** — Ask to save something important, Claude saves it for the team
 
@@ -80,6 +81,7 @@ SUPERMEMORY_DEBUG=true           # Optional: enable debug logging
 | Option              | Description                                   |
 | ------------------- | --------------------------------------------- |
 | `maxProfileItems`   | Max memories in context (default: 5)          |
+| `recallDirective`   | Override the built-in reasoned-recall instruction Claude is given |
 | `signalExtraction`  | Only capture important turns (default: false) |
 | `signalKeywords`    | Keywords that trigger capture                 |
 | `signalTurnsBefore` | Context turns before signal (default: 3)      |

--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "updateCommand": "/plugin marketplace update supermemory-plugins\n/plugin install supermemory@supermemory-plugins\n\nOnly if you still have the old \"claude-supermemory\" plugin, also remove it:\n/plugin uninstall claude-supermemory@supermemory-plugins"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-supermemory-dev",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-supermemory-dev",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "dependencies": {
         "supermemory": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-supermemory-dev",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Claude code plugin by Supermemory AI",
   "private": true,
   "type": "commonjs",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supermemory",
   "displayName": "Supermemory",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Persistent memory across Claude Code sessions using Supermemory",
   "author": {
     "name": "Supermemory",

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -12,6 +12,29 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/recall-hook.cjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Skill|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/recall-approve.cjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-supermemory",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-supermemory",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-supermemory",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Persistent memory for Claude Code using Supermemory",
   "private": true,
   "engines": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,6 +9,8 @@ const OUT = path.join(ROOT, 'plugin', 'scripts');
 
 const hooks = [
   'context-hook',
+  'recall-hook',
+  'recall-approve',
   'summary-hook',
   'search-memory',
   'add-memory',

--- a/src/lib/plugin-version.js
+++ b/src/lib/plugin-version.js
@@ -1,3 +1,3 @@
-const PLUGIN_VERSION = '0.0.7';
+const PLUGIN_VERSION = '0.0.8';
 
 module.exports = { PLUGIN_VERSION };

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -16,6 +16,7 @@ const DEFAULT_SETTINGS = {
   maxProfileItems: 5,
   debug: false,
   injectProfile: true,
+  recallDirective: null,
   signalExtraction: false,
   signalKeywords: [
     'remember',
@@ -158,6 +159,16 @@ function getSignalConfig(cwd) {
   return { enabled, keywords, turnsBefore };
 }
 
+function getRecallConfig(cwd) {
+  const settings = loadSettings();
+  const projectConfig = loadProjectConfig(cwd || process.cwd());
+
+  const directive =
+    projectConfig?.recallDirective || settings.recallDirective || null;
+
+  return { directive };
+}
+
 module.exports = {
   SETTINGS_DIR,
   SETTINGS_FILE,
@@ -170,4 +181,5 @@ module.exports = {
   getIncludeTools,
   shouldIncludeTool,
   getSignalConfig,
+  getRecallConfig,
 };

--- a/src/recall-approve.js
+++ b/src/recall-approve.js
@@ -1,0 +1,49 @@
+const { loadSettings, debugLog } = require('./lib/settings');
+const { readStdin, writeOutput } = require('./lib/stdin');
+
+const SEARCH_BASH_RE = /node[\s\S]*search-memory\.cjs/;
+const SHELL_OPS = /[;&|`>]|\$\(/;
+const SEARCH_SKILL = 'supermemory-search';
+
+function isSupermemorySearch(toolName, toolInput) {
+  if (toolName === 'Skill') {
+    return JSON.stringify(toolInput || {}).includes(SEARCH_SKILL);
+  }
+  if (toolName === 'Bash') {
+    const cmd = String(toolInput?.command || '');
+    return SEARCH_BASH_RE.test(cmd) && !SHELL_OPS.test(cmd);
+  }
+  return false;
+}
+
+async function main() {
+  const settings = loadSettings();
+
+  try {
+    const input = await readStdin();
+
+    if (isSupermemorySearch(input.tool_name, input.tool_input)) {
+      debugLog(settings, 'Auto-approving recall search', {
+        toolName: input.tool_name,
+      });
+      writeOutput({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason:
+            'Supermemory reasoned recall runs automatically (read-only memory search).',
+        },
+      });
+      return;
+    }
+
+    writeOutput({ continue: true, suppressOutput: true });
+  } catch (err) {
+    debugLog(settings, 'Recall approve hook error', { error: err.message });
+    writeOutput({ continue: true, suppressOutput: true });
+  }
+}
+
+main().catch(() => {
+  writeOutput({ continue: true, suppressOutput: true });
+});

--- a/src/recall-hook.js
+++ b/src/recall-hook.js
@@ -1,0 +1,57 @@
+const { loadSettings, debugLog, getRecallConfig } = require('./lib/settings');
+const { readStdin, writeOutput } = require('./lib/stdin');
+
+const DEFAULT_RECALL_DIRECTIVE = `<supermemory-recall>
+Before responding, silently decide whether recalling saved memory (past sessions, decisions, conventions, the user's preferences) would materially improve your answer to THIS message. Reason first — don't search reflexively, and don't narrate the decision.
+
+Recall — via the supermemory-search skill — when the message:
+- refers to earlier work or decisions ("the auth flow", "like we did", "continue", "the bug from before")
+- touches an area where saved conventions, patterns, or preferences likely exist
+- is ambiguous in a way past context would resolve
+
+Skip recall when the message is self-contained, trivial, a greeting/meta, fully answerable from the current conversation, or you already recalled the relevant context this session and the topic hasn't shifted.
+
+Cadence is per-message: it's fine to recall on several turns in a row, and fine to never recall in a session. When you do recall, run it before answering and fold the results into your response.
+</supermemory-recall>`;
+
+const RECALL_DEBUG_SUFFIX = `<recall-debug>
+DEBUG MODE: Begin your reply with exactly one line, then continue normally:
+[recall-decision] yes|no — <short reason>
+"yes" means you are recalling saved Supermemory memory (via the supermemory-search skill, separate from any obsidian/smfs notes mount) for THIS message; "no" means you are skipping it.
+</recall-debug>`;
+
+async function main() {
+  const settings = loadSettings();
+
+  try {
+    const input = await readStdin();
+    const cwd = input.cwd || process.cwd();
+
+    const { directive } = getRecallConfig(cwd);
+
+    let additionalContext = directive || DEFAULT_RECALL_DIRECTIVE;
+    if (settings.debug) {
+      additionalContext += `\n\n${RECALL_DEBUG_SUFFIX}`;
+    }
+
+    debugLog(settings, 'Injecting recall directive', {
+      sessionId: input.session_id,
+      custom: !!directive,
+      debugDecision: !!settings.debug,
+    });
+
+    writeOutput({
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext,
+      },
+    });
+  } catch (err) {
+    debugLog(settings, 'Recall hook error', { error: err.message });
+    writeOutput({ continue: true, suppressOutput: true });
+  }
+}
+
+main().catch(() => {
+  writeOutput({ continue: true, suppressOutput: true });
+});


### PR DESCRIPTION
Re-introduces reasoned per-turn memory recall (previously merged in #55, reverted in #64).

## What it does

- **recall-hook** (`UserPromptSubmit`): injects a per-turn directive so Claude reasons about whether recalling saved memory would help _this_ message — searching every turn, occasionally, or not at all.
- **recall-approve** (`PreToolUse`): auto-approves _only_ the `supermemory-search` tool call so recall is silent like auto-capture. Narrow allow-list; rejects shell-laced commands (`;`, `&`, `|`, backtick, `>`, `$()`), every other tool falls through to the normal permission flow.
- **settings**: `recallDirective` override + `getRecallConfig()`.
- **wiring**: `plugin/hooks/hooks.json` + `scripts/build.js`, version bump `0.0.7 → 0.0.8`.

## 

🤖 Generated with [Claude Code](https://claude.com/claude-code)