### PR TITLE
Migrate metadata out of the sm_ namespace (agent_scope et al.)

### DIFF
--- a/plugin/hooks/capture.js
+++ b/plugin/hooks/capture.js
@@ -66,9 +66,9 @@ async function main() {
       {
         type: 'session_turn',
         project: getProjectName(cwd),
-        sm_project_id: getProjectIdentity(cwd),
+        agent_project_id: getProjectIdentity(cwd),
         agent_scope: 'personal',
-        sm_capture_mode: 'automatic',
+        agent_capture_mode: 'automatic',
         timestamp: new Date().toISOString(),
       },
       { customId: sessionId, entityContext: AGENT_ENTITY_CONTEXT },

--- a/plugin/hooks/capture.js
+++ b/plugin/hooks/capture.js
@@ -67,7 +67,7 @@ async function main() {
         type: 'session_turn',
         project: getProjectName(cwd),
         sm_project_id: getProjectIdentity(cwd),
-        sm_scope: 'personal',
+        agent_scope: 'personal',
         sm_capture_mode: 'automatic',
         timestamp: new Date().toISOString(),
       },

--- a/plugin/hooks/lib/api.js
+++ b/plugin/hooks/lib/api.js
@@ -40,8 +40,17 @@ async function post(baseUrl, apiKey, path, body, timeoutMs = 15000) {
   return response.json();
 }
 
+// Canonical-container reads filter on searchable agent_scope metadata; legacy
+// containers stay unfiltered. Requires the backend sm_scope→agent_scope
+// backfill (mono#2895) to be deployed, or filtered reads return nothing.
+function scopeFilters(scope) {
+  return { AND: [{ key: 'agent_scope', value: scope, filterType: 'metadata' }] };
+}
+
 function getProfile(baseUrl, apiKey, containerTag, query, options = {}) {
-  return post(baseUrl, apiKey, '/v4/profile', { containerTag, q: query }, options.timeoutMs);
+  const body = { containerTag, q: query };
+  if (options.filters) body.filters = options.filters;
+  return post(baseUrl, apiKey, '/v4/profile', body, options.timeoutMs);
 }
 
 function addMemory(baseUrl, apiKey, content, containerTag, metadata, options = {}) {
@@ -55,4 +64,4 @@ function addMemory(baseUrl, apiKey, content, containerTag, metadata, options = {
   return post(baseUrl, apiKey, '/v3/documents', body, options.timeoutMs);
 }
 
-module.exports = { AGENT_ENTITY_CONTEXT, getProfile, addMemory };
+module.exports = { AGENT_ENTITY_CONTEXT, getProfile, addMemory, scopeFilters };

--- a/plugin/hooks/lib/api.js
+++ b/plugin/hooks/lib/api.js
@@ -57,7 +57,7 @@ function addMemory(baseUrl, apiKey, content, containerTag, metadata, options = {
   const body = {
     content,
     containerTag,
-    metadata: { sm_source: 'claude-code', ...metadata },
+    metadata: { agent_source: 'claude-code', ...metadata },
   };
   if (options.customId) body.customId = options.customId;
   if (options.entityContext) body.entityContext = options.entityContext;

--- a/plugin/hooks/recall-directive.js
+++ b/plugin/hooks/recall-directive.js
@@ -2,7 +2,7 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { getProfile } = require('./lib/api');
+const { getProfile, scopeFilters } = require('./lib/api');
 const { BRAND, gray, red } = require('./lib/colors');
 const { getContainerTag } = require('./lib/container-tag');
 const { loadProjectConfig } = require('./lib/project-config');
@@ -125,7 +125,7 @@ async function main() {
       apiKey,
       containerTag,
       prompt.slice(0, MAX_QUERY_LENGTH),
-      { timeoutMs: SEARCH_TIMEOUT_MS },
+      { timeoutMs: SEARCH_TIMEOUT_MS, filters: scopeFilters('personal') },
     );
 
     const results = (response?.searchResults?.results || [])

--- a/plugin/hooks/session-start.js
+++ b/plugin/hooks/session-start.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { getProfile } = require('./lib/api');
+const { getProfile, scopeFilters } = require('./lib/api');
 const { getContainerTag, getProjectName } = require('./lib/container-tag');
 const { loadProjectConfig } = require('./lib/project-config');
 const {
@@ -174,7 +174,9 @@ Or set the SUPERMEMORY_CC_API_KEY environment variable.
     let profileResult = null;
     let apiError = null;
     try {
-      profileResult = await getProfile(baseUrl, apiKey, containerTag, projectName);
+      profileResult = await getProfile(baseUrl, apiKey, containerTag, projectName, {
+        filters: scopeFilters('personal'),
+      });
     } catch (err) {
       if (!isBenignError(err)) apiError = getUserFriendlyError(err);
       debugLog(settings, 'Profile fetch failed', { error: err.message });

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -210,6 +210,9 @@ describe('recall-directive hook', () => {
       JSON.parse(stub.requests[0].body).q,
       'continue the database work from before',
     );
+    assert.deepEqual(JSON.parse(stub.requests[0].body).filters, {
+      AND: [{ key: 'agent_scope', value: 'personal', filterType: 'metadata' }],
+    });
 
     const state = readState('s1', {
       dataDir: join(home, '.supermemory-claude', 'statusline'),
@@ -388,6 +391,9 @@ describe('session-start hook', () => {
     assert.match(plain(output.systemMessage), /◪ supermemory · 2 memories loaded for Example\.Project/);
     assert.equal(stub.requests[0].url, '/v4/profile');
     assert.match(stub.requests[0].headers.authorization, /^Bearer sm_test/);
+    assert.deepEqual(JSON.parse(stub.requests[0].body).filters, {
+      AND: [{ key: 'agent_scope', value: 'personal', filterType: 'metadata' }],
+    });
 
     const state = readState('sess-1', {
       dataDir: join(home, '.supermemory-claude', 'statusline'),
@@ -440,7 +446,8 @@ describe('capture hook', () => {
     const body = JSON.parse(stub.requests[0].body);
     assert.match(body.content, /statusline symlink/);
     assert.match(body.containerTag, /^repo_example_project__/);
-    assert.equal(body.metadata.sm_scope, 'personal');
+    assert.equal(body.metadata.agent_scope, 'personal');
+    assert.equal('sm_scope' in body.metadata, false);
     assert.equal(body.customId, 'sess-2');
     assert.match(body.entityContext, /EXTRACT/);
 

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -447,7 +447,9 @@ describe('capture hook', () => {
     assert.match(body.content, /statusline symlink/);
     assert.match(body.containerTag, /^repo_example_project__/);
     assert.equal(body.metadata.agent_scope, 'personal');
-    assert.equal('sm_scope' in body.metadata, false);
+    assert.equal(body.metadata.agent_source, 'claude-code');
+    // sm_* is Supermemory's internal namespace — plugin metadata must never use it.
+    assert.deepEqual(Object.keys(body.metadata).filter((k) => k.startsWith('sm_')), []);
     assert.equal(body.customId, 'sess-2');
     assert.match(body.entityContext, /EXTRACT/);
 


### PR DESCRIPTION
## Summary

Ports #92 onto the CLI-free architecture and finishes the rule behind it: **nothing the plugin writes may use the `sm_` prefix** — that's Supermemory's internal namespace.

- Writes: `agent_scope` (was reserved `sm_scope`), `agent_project_id`, `agent_capture_mode`, `agent_source`.
- Reads: canonical-container profile/search requests filter on `agent_scope` metadata; legacy containers stay unfiltered for compatibility.
- The capture test asserts no metadata key starts with `sm_`.

## ⛔ Release gate

**Do not merge/release until supermemoryai/mono#2895 (the sm_scope→agent_scope backfill) is deployed and complete.** Until then, filtered canonical reads return nothing — a silent recall outage. Note for the backfill: this PR also renames `sm_project_id`/`sm_capture_mode`/`sm_source`; only `agent_scope` is read-critical, but the backfill should cover all four for consistency.

Supersedes #92, which targeted the pre-refactor file layout.

## Test plan

- `node --test test/unit.mjs` — 23 passing; capture asserts the agent_* keys and the sm_-free invariant, recall and session-start assert the filter shape on stubbed /v4/profile requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)