### PR TITLE
Entity context: remember like a human, skip git-tracked state

### DIFF
--- a/plugin/hooks/lib/api.js
+++ b/plugin/hooks/lib/api.js
@@ -1,6 +1,7 @@
 const AGENT_ENTITY_CONTEXT = `Shared coding-agent memory for one software repository.
 
 RULES:
+- Try to remember things that a human would remember — a teammate recalls decisions and lessons, not what state the working tree was in
 - Preserve durable context that helps a coding agent continue the work
 - Condense assistant responses into decisions, outcomes, and reusable knowledge
 - Keep user preferences and project facts concise and independently understandable
@@ -14,6 +15,7 @@ EXTRACT:
 - Decisions: "chose Drizzle over Prisma for performance", "using RSC for data fetching"
 
 SKIP:
+- Transient repo state git already tracks: uncommitted file lists, current branch position, in-flight commit/push status
 - Generic assistant suggestions the user did not accept
 - Transient command output and low-value implementation chatter
 - Granular details that do not help future work`;


### PR DESCRIPTION
## Summary

Automatic capture was producing memories like:

> Current working copy of the Dhravya/statusline-feature branch contains uncommitted changes to recall-approve.js, … ready to be committed to PR #71.

That's a snapshot of working-tree state — git already tracks it, it's stale within minutes, and no human teammate would commit it to memory. The extraction entity context now:

- leads with **"Try to remember things that a human would remember — a teammate recalls decisions and lessons, not what state the working tree was in"**
- explicitly SKIPs transient repo state git already tracks: uncommitted file lists, current branch position, in-flight commit/push status

## Test plan

- `node --test test/unit.mjs` — 23 passing (the capture test asserts the entity context is sent; extraction-quality change is prompt-side, observed on live captures after release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)