### PR TITLE
fix: surface search hit titles in recall injections

### DIFF
--- a/plugin/hooks/recall-directive.js
+++ b/plugin/hooks/recall-directive.js
@@ -76,7 +76,8 @@ function readSeenHashes(sessionDir) {
 function formatRecall(results, containerTag) {
   const lines = results.map((r) => {
     const text = resultText(r).replace(/\s+/g, ' ').slice(0, MAX_RESULT_CHARS);
-    return `- ◪ ${text}${typeof r.filepath === 'string' && r.filepath ? ` (${r.filepath})` : ''}`;
+    const label = typeof r.title === 'string' && r.title.trim() ? `${r.title.trim()}: ` : '';
+    return `- ◪ ${label}${text}${typeof r.filepath === 'string' && r.filepath ? ` (${r.filepath})` : ''}`;
   });
   return `<supermemory-recall>
 ◪ Recalled from supermemory for this prompt (relevance-ranked):

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -181,7 +181,7 @@ describe('recall-directive hook', () => {
             results: [
               { memory: 'Chose Drizzle over Prisma', similarity: 0.82 },
               { chunk: 'export const db = drizzle(client)', filepath: 'src/db.ts', similarity: 0.74 },
-              { memory: 'Errors must be loud and obvious', similarity: 0.71 },
+              { memory: 'Errors must be loud and obvious', title: 'Error handling', similarity: 0.71 },
               { memory: 'irrelevant low-similarity hit', similarity: 0.2 },
             ],
           },
@@ -201,7 +201,7 @@ describe('recall-directive hook', () => {
     assert.match(context, /<supermemory-recall>/);
     assert.match(context, /- ◪ Chose Drizzle over Prisma/);
     assert.match(context, /- ◪ export const db = drizzle\(client\) \(src\/db\.ts\)/);
-    assert.match(context, /- ◪ Errors must be loud and obvious/);
+    assert.match(context, /- ◪ Error handling: Errors must be loud and obvious/);
     assert.doesNotMatch(context, /irrelevant low-similarity hit/);
     assert.match(context, /repo_example_project__/);
     assert.equal(plain(output.systemMessage), '◪ supermemory · recalled 3 memories');


### PR DESCRIPTION
## Summary
- `resultText()`/`formatRecall()` in `recall-directive.js` rendered memory/chunk text and filepath but dropped the `title` field the API already returns on search hits — the only thing distinguishing similar-looking results.
- Recalled lines now prefix with `Title: ` when a title is present, matching the format used before the CLI-free restructure.

Ports the idea from #88 (closed as stale after the #71 refactor removed `plugin/scripts/`), reopened as #94.

## Test plan
- [x] `node --test test/unit.mjs` — all 23 tests pass, including an added assertion covering a titled search hit