### PR TITLE
fix: status command now proves live connectivity instead of assuming it

### DIFF
--- a/plugin/commands/status.md
+++ b/plugin/commands/status.md
@@ -1,6 +1,6 @@
 ---
 description: Show Supermemory authentication and connection status
-allowed-tools: ["Bash", "Read"]
+allowed-tools: ["Bash", "Read", "mcp__supermemory__whoAmI", "mcp__plugin_supermemory_supermemory__whoAmI", "mcp__claude_ai_supermemory__whoAmI"]
 ---
 
 # Supermemory Status
@@ -8,7 +8,7 @@ allowed-tools: ["Bash", "Read"]
 Report the user's Supermemory status:
 
 1. Read `~/.supermemory-claude/credentials.json` (may not exist). Never print the full API key — show at most the first 6 and last 4 characters.
-2. Call the `whoAmI` MCP tool if the supermemory MCP server is connected.
-3. Report: authenticated or not, key source (env `SUPERMEMORY_CC_API_KEY` beats credentials file), the active project container tag, and whether the MCP server is reachable.
+2. If a key is configured (env or file), you MUST call whichever `whoAmI` tool variant is available (`mcp__supermemory__whoAmI`, `mcp__plugin_supermemory_supermemory__whoAmI`, or `mcp__claude_ai_supermemory__whoAmI`) to prove the endpoint is actually reachable — do not infer reachability from the key's presence alone. If none of those tools resolve, the MCP server isn't connected; report that explicitly rather than skipping the check silently.
+3. Report: authenticated or not, key source (env `SUPERMEMORY_CC_API_KEY` beats credentials file), the active project container tag, and a live reachability verdict — "reachable" only after a successful `whoAmI` call, "unreachable" if the call errored or returned auth failure, "MCP server not connected" if no `whoAmI` tool was available at all.
 
 If not authenticated, tell the user a new session will open the browser login automatically, or they can set `SUPERMEMORY_CC_API_KEY`.


### PR DESCRIPTION
## Summary
- \`allowed-tools\` on \`/supermemory:status\` only listed \`Bash\` and \`Read\`, so step 2's instruction to "call the whoAmI MCP tool" had no tool it was actually permitted to call — reachability was effectively inferred from stored credentials existing, never verified against the live endpoint.
- Added the three \`whoAmI\` namespace variants (direct, plugin-scoped, claude.ai connector) to \`allowed-tools\`.
- Made the call mandatory when a key is configured, not conditional.
- Command now reports an explicit reachable / unreachable / not-connected verdict.

Ports the idea from #87 (closed as stale after the #71 refactor removed \`status.cjs\`), reopened as #95.

## Test plan
- [x] \`node --test test/unit.mjs\` — all 23 tests pass (this file isn't hook-tested, it's a prompt-driven command)
- [ ] Manual: run \`/supermemory:status\` with a valid key and confirm it reports "reachable"; with an invalid/expired key confirm it reports "unreachable" instead of silently claiming success