### PR TITLE
Capture cursor advances only after a successful save

### DIFF
--- a/plugin/hooks/capture.js
+++ b/plugin/hooks/capture.js
@@ -13,7 +13,11 @@ const {
   getSignalConfig,
 } = require('./lib/settings');
 const { readStdin, writeOutput } = require('./lib/stdin');
-const { formatNewEntries, formatSignalEntries } = require('./lib/transcript');
+const {
+  formatNewEntries,
+  formatSignalEntries,
+  setLastCapturedUuid,
+} = require('./lib/transcript');
 const { getUserFriendlyError } = require('./lib/error-helpers');
 const { saveLastSession } = require('./lib/last-session');
 const { readState, writeState } = require('./lib/statusline-state');
@@ -42,11 +46,11 @@ async function main() {
       return;
     }
 
-    const formatted = getSignalConfig(cwd).enabled
+    const delta = getSignalConfig(cwd).enabled
       ? formatSignalEntries(transcriptPath, sessionId, cwd)
       : formatNewEntries(transcriptPath, sessionId, cwd);
 
-    if (!formatted) {
+    if (!delta) {
       debugLog(settings, 'No new content to save');
       writeOutput({ continue: true });
       return;
@@ -61,7 +65,7 @@ async function main() {
     const result = await addMemory(
       baseUrl,
       apiKey,
-      formatted,
+      delta.formatted,
       containerTag,
       {
         type: 'session_turn',
@@ -74,6 +78,7 @@ async function main() {
       { customId: sessionId, entityContext: AGENT_ENTITY_CONTEXT },
     );
 
+    setLastCapturedUuid(sessionId, delta.lastUuid);
     writeState(sessionId, 'capture', { status: 'saved', count: captured + 1 });
 
     if (result?.id) {
@@ -82,7 +87,7 @@ async function main() {
       } catch {}
     }
 
-    debugLog(settings, 'Session turn saved', { length: formatted.length });
+    debugLog(settings, 'Session turn saved', { length: delta.formatted.length });
     writeOutput({ continue: true });
   } catch (err) {
     const friendly = getUserFriendlyError(err);

--- a/plugin/hooks/lib/transcript.js
+++ b/plugin/hooks/lib/transcript.js
@@ -451,9 +451,9 @@ function formatSignalEntries(transcriptPath, sessionId, cwd) {
 
   if (result.length < 100) return null;
 
-  setLastCapturedUuid(sessionId, lastEntry.uuid);
-
-  return result;
+  // The caller advances the cursor only after the save succeeds — advancing
+  // here would silently drop this delta whenever the API call fails.
+  return { formatted: result, lastUuid: lastEntry.uuid };
 }
 
 function formatNewEntries(transcriptPath, sessionId, cwd) {
@@ -489,9 +489,9 @@ function formatNewEntries(transcriptPath, sessionId, cwd) {
 
   if (result.length < 100) return null;
 
-  setLastCapturedUuid(sessionId, lastEntry.uuid);
-
-  return result;
+  // The caller advances the cursor only after the save succeeds — advancing
+  // here would silently drop this delta whenever the API call fails.
+  return { formatted: result, lastUuid: lastEntry.uuid };
 }
 
 module.exports = {

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -449,6 +449,47 @@ describe('capture hook', () => {
     });
     assert.equal(state.capture.status, 'saved');
   });
+
+  test('a failed save does not advance the cursor; the retry recaptures (issue #96)', async (t) => {
+    const { repo, home } = makeRepo(t);
+    mkdirSync(join(home, '.supermemory-claude'), { recursive: true });
+    writeFileSync(
+      join(home, '.supermemory-claude', 'credentials.json'),
+      JSON.stringify({ apiKey: 'sm_test_key_0123456789abcdef' }),
+    );
+    const transcript = join(makeTempDir(t, 'transcript-retry'), 'session.jsonl');
+    writeFileSync(
+      transcript,
+      JSON.stringify({
+        type: 'user',
+        uuid: 'u1',
+        timestamp: '2026-08-18T20:00:00Z',
+        message: { content: 'Remember: we chose Drizzle over Prisma for performance' },
+      }),
+    );
+    let failing = true;
+    const stub = await startStubServer(t, (record, res) => {
+      res.statusCode = failing ? 500 : 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(failing ? { error: 'boom' } : { id: 'doc_9' }));
+    });
+    const env = { HOME: home, USERPROFILE: home, SUPERMEMORY_API_URL: stub.url };
+    const input = { session_id: 'sess-retry', cwd: repo, transcript_path: transcript };
+
+    await runHook('capture.js', input, env);
+    const dataDir = join(home, '.supermemory-claude', 'statusline');
+    assert.equal(readState('sess-retry', { dataDir }).capture.status, 'error');
+
+    failing = false;
+    await runHook('capture.js', input, env);
+    assert.equal(stub.requests.length, 2);
+    assert.match(JSON.parse(stub.requests[1].body).content, /Drizzle over Prisma/);
+    assert.equal(readState('sess-retry', { dataDir }).capture.status, 'saved');
+
+    // Cursor advanced after success: a third run finds nothing new.
+    await runHook('capture.js', input, env);
+    assert.equal(stub.requests.length, 2);
+  });
 });
 
 describe('mcp proxy', () => {


### PR DESCRIPTION
The tracker uuid advanced inside the formatters, before the API call — so any failed save silently and permanently skipped that turn's content (the exact tracker-first ordering @catShaark flagged in #84, alive in the new architecture). Formatters now return `{ formatted, lastUuid }`; capture.js advances the cursor only after `addMemory` succeeds. A transient failure now means recapture on the next Stop instead of silent loss.

Regression test: failed save leaves cursor put and statusline in `error`; retry re-sends the same content; third run confirms the cursor advanced after success.

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)