### PR TITLE
/supermemory:status verifies real connectivity

### DIFF
--- a/plugin/commands/status.md
+++ b/plugin/commands/status.md
@@ -7,8 +7,15 @@ allowed-tools: ["Bash", "Read"]
 
 Report the user's Supermemory status:
 
-1. Read `~/.supermemory-claude/credentials.json` (may not exist). Never print the full API key — show at most the first 6 and last 4 characters.
-2. Call the `whoAmI` MCP tool if the supermemory MCP server is connected.
-3. Report: authenticated or not, key source (env `SUPERMEMORY_CC_API_KEY` beats credentials file), the active project container tag, and whether the MCP server is reachable.
+1. Read `~/.supermemory-claude/credentials.json` (may not exist). Never print the full API key — show at most the first 6 and last 4 characters. The key source is env `SUPERMEMORY_CC_API_KEY` when set, otherwise the credentials file.
+2. **Probe real connectivity** — a stored key proves nothing by itself. With the resolved key, run:
+   ```
+   curl -sS -o /dev/null -w '%{http_code}' -m 8 -X POST "${SUPERMEMORY_API_URL:-https://api.supermemory.ai}/v4/profile" \
+     -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -H "x-sm-source: claude-code" \
+     -d '{"containerTag":"<this project's container tag>","q":"connectivity probe"}'
+   ```
+   Interpret loudly: `200` → reachable and the key works; `401`/`403` → reachable but the key is invalid or revoked (say so explicitly — this is the silent-failure case the probe exists to catch); timeout / connection error / `5xx` → API unreachable, report the exact error.
+3. Call the `whoAmI` MCP tool if the supermemory MCP server is connected, and say whether the MCP path works too.
+4. Report: authenticated or not, key source, the active project container tag, API reachability (with the probe's HTTP status), and MCP reachability.
 
 If not authenticated, tell the user a new session will open the browser login automatically, or they can set `SUPERMEMORY_CC_API_KEY`.


### PR DESCRIPTION
The status command reported the stored key and container without ever touching the network — a revoked key looked healthy. It now probes `/v4/profile` with the resolved key and reports the HTTP status, explicitly distinguishing: 200 (key works), 401/403 (reachable, key invalid — the silent-failure case), timeout/5xx (API unreachable). MCP reachability is reported separately via whoAmI.

Verified live: real key → 200, invalid key → 401.

Ports @ayushsingh82's idea from #87. Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)