### PR TITLE
chore: bump to 0.1.4

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.1.3",
+  "version": "0.1.4",
   "updateCommand": "claude plugin update supermemory@supermemory-plugins"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-supermemory-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Claude code plugin by Supermemory AI",
   "private": true,
   "type": "commonjs",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supermemory",
   "displayName": "Supermemory",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Persistent memory across Claude Code sessions using Supermemory",
   "author": {
     "name": "Supermemory",


### PR DESCRIPTION
Version 0.1.4 in plugin.json, latest.json, and package.json.

**Merge last**, after the 0.1.4 content lands: #98 (human-memorable entity context), #101 (capture cursor after save), #102 (recall titles), #103 (status connectivity probe). Not included: #97 (agent_scope migration — draft, gated on mono#2895).

🤖 Generated with [Claude Code](https://claude.com/claude-code)