### PR TITLE
Grok Build compatibility

### DIFF
--- a/plugin/hooks/capture.js
+++ b/plugin/hooks/capture.js
@@ -13,9 +13,12 @@ const {
   getSignalConfig,
 } = require('./lib/settings');
 const { readStdin, writeOutput } = require('./lib/stdin');
+const { normalizeHookInput } = require('./lib/hook-input');
 const {
+  formatGrokEntries,
   formatNewEntries,
   formatSignalEntries,
+  isGrokTranscript,
   setLastCapturedUuid,
 } = require('./lib/transcript');
 const { getUserFriendlyError } = require('./lib/error-helpers');
@@ -27,7 +30,7 @@ async function main() {
   let sessionId;
 
   try {
-    const input = await readStdin();
+    const input = normalizeHookInput(await readStdin());
     const cwd = input.cwd || process.cwd();
     sessionId = input.session_id;
     const transcriptPath = input.transcript_path;
@@ -46,9 +49,11 @@ async function main() {
       return;
     }
 
-    const delta = getSignalConfig(cwd).enabled
-      ? formatSignalEntries(transcriptPath, sessionId, cwd)
-      : formatNewEntries(transcriptPath, sessionId, cwd);
+    const delta = isGrokTranscript(transcriptPath)
+      ? formatGrokEntries(transcriptPath, sessionId)
+      : getSignalConfig(cwd).enabled
+        ? formatSignalEntries(transcriptPath, sessionId, cwd)
+        : formatNewEntries(transcriptPath, sessionId, cwd);
 
     if (!delta) {
       debugLog(settings, 'No new content to save');

--- a/plugin/hooks/lib/hook-input.js
+++ b/plugin/hooks/lib/hook-input.js
@@ -1,0 +1,18 @@
+// Grok Build runs Claude-format plugin hooks but delivers camelCase field
+// names (sessionId, transcriptPath) and wraps the prompt in <user_query>
+// tags. Normalize to the Claude shape so every hook handles both hosts.
+function normalizeHookInput(input) {
+  const isGrok = 'sessionId' in input && !('session_id' in input);
+  const prompt = (input.prompt || '')
+    .replace(/^\s*<user_query>\s*/i, '')
+    .replace(/\s*<\/user_query>\s*$/i, '');
+  return {
+    ...input,
+    isGrok,
+    prompt,
+    session_id: input.session_id ?? input.sessionId,
+    transcript_path: input.transcript_path ?? input.transcriptPath,
+  };
+}
+
+module.exports = { normalizeHookInput };

--- a/plugin/hooks/lib/transcript.js
+++ b/plugin/hooks/lib/transcript.js
@@ -494,12 +494,49 @@ function formatNewEntries(transcriptPath, sessionId, cwd) {
   return { formatted: result, lastUuid: lastEntry.uuid };
 }
 
+// Grok Build hooks point transcriptPath at the session's updates.jsonl (ACP
+// event records); the readable conversation lives in the sibling
+// chat_history.jsonl as {type, content} lines. Entries have no uuids, so the
+// cursor stores a processed-line count instead.
+function isGrokTranscript(transcriptPath) {
+  return path.basename(transcriptPath || '') === 'updates.jsonl';
+}
+
+function formatGrokEntries(transcriptPath, sessionId) {
+  const chatHistory = path.join(path.dirname(transcriptPath), 'chat_history.jsonl');
+  const convo = parseTranscript(chatHistory).filter(
+    (e) =>
+      (e.type === 'user' || e.type === 'assistant') &&
+      typeof e.content === 'string' &&
+      e.content.trim(),
+  );
+
+  const cursor = getLastCapturedUuid(sessionId);
+  const start =
+    cursor?.startsWith('grok:') ? Number.parseInt(cursor.slice(5), 10) || 0 : 0;
+  const fresh = convo.slice(start);
+  if (fresh.length === 0) return null;
+
+  const parts = [`<|turn_start|>${new Date().toISOString()}`];
+  for (const entry of fresh) {
+    const text = cleanContent(entry.content.replace(/<\/?user_query>/g, ''));
+    if (text) parts.push(`<|start|>${entry.type}<|message|>${text}<|end|>`);
+  }
+  parts.push('<|turn_end|>');
+
+  const result = parts.join('\n\n');
+  if (result.length < 100) return null;
+  return { formatted: result, lastUuid: `grok:${convo.length}` };
+}
+
 module.exports = {
   parseTranscript,
   getEntriesSinceLastCapture,
   formatEntry,
   formatNewEntries,
   formatSignalEntries,
+  formatGrokEntries,
+  isGrokTranscript,
   cleanContent,
   truncate,
   getLastCapturedUuid,

--- a/plugin/hooks/recall-approve.js
+++ b/plugin/hooks/recall-approve.js
@@ -1,6 +1,7 @@
 const { BRAND, gray } = require('./lib/colors');
 const { loadSettings, debugLog } = require('./lib/settings');
 const { readState, writeState } = require('./lib/statusline-state');
+const { normalizeHookInput } = require('./lib/hook-input');
 const { readStdin, writeOutput } = require('./lib/stdin');
 
 // Supermemory MCP tool names arrive as mcp__supermemory__<tool> (direct
@@ -23,7 +24,7 @@ async function main() {
   const settings = loadSettings();
 
   try {
-    const input = await readStdin();
+    const input = normalizeHookInput(await readStdin());
     const tool = TOOL_NAME_RE.exec(input.tool_name || '')?.[1];
 
     if (tool && READ_ONLY_TOOLS.has(tool)) {

--- a/plugin/hooks/recall-directive.js
+++ b/plugin/hooks/recall-directive.js
@@ -4,6 +4,7 @@ const path = require('node:path');
 
 const { getProfile } = require('./lib/api');
 const { BRAND, gray, red } = require('./lib/colors');
+const { normalizeHookInput } = require('./lib/hook-input');
 const { getContainerTag } = require('./lib/container-tag');
 const { loadProjectConfig } = require('./lib/project-config');
 const {
@@ -73,17 +74,28 @@ function readSeenHashes(sessionDir) {
   }
 }
 
-function formatRecall(results, containerTag) {
+// Grok Build does not run plugin SessionStart hooks, so the first recall of a
+// session also carries the profile that session-start would have injected —
+// the /v4/profile response already contains both, costing no extra call.
+function formatProfile(profile) {
+  const items = [...(profile?.static || []), ...(profile?.dynamic || [])];
+  if (items.length === 0) return '';
+  return `\nUser profile from supermemory:\n${items.map((f) => `- ◪ ${f}`).join('\n')}\n`;
+}
+
+function formatRecall(results, containerTag, profileBlock = '') {
   const lines = results.map((r) => {
     const text = resultText(r).replace(/\s+/g, ' ').slice(0, MAX_RESULT_CHARS);
     const title = typeof r.title === 'string' && r.title.trim() ? r.title.trim() : null;
     const prefix = title && !text.startsWith(title) ? `${title} — ` : '';
     return `- ◪ ${prefix}${text}${typeof r.filepath === 'string' && r.filepath ? ` (${r.filepath})` : ''}`;
   });
+  const recallSection =
+    lines.length > 0
+      ? `◪ Recalled from supermemory for this prompt (relevance-ranked):\n${lines.join('\n')}\n`
+      : '';
   return `<supermemory-recall>
-◪ Recalled from supermemory for this prompt (relevance-ranked):
-${lines.join('\n')}
-
+${profileBlock}${recallSection}
 When one of these shapes your answer, credit it naturally with the ◪ prefix (e.g. "◪ earlier you decided X"); if you name the source, say "from supermemory" — never "from memory". For deeper history, call the supermemory search_memory tool (containerTag: "${containerTag}") or launch the context-gatherer agent.
 </supermemory-recall>`;
 }
@@ -92,9 +104,9 @@ async function main() {
   const settings = loadSettings();
 
   try {
-    const input = await readStdin();
+    const input = normalizeHookInput(await readStdin());
     const cwd = input.cwd || process.cwd();
-    const prompt = (input.prompt || '').trim();
+    const prompt = input.prompt.trim();
     const { directive } = getRecallConfig(cwd);
 
     if (directive) {
@@ -141,6 +153,19 @@ async function main() {
     const fresh = results.filter((r) => !seenSet.has(hashText(resultText(r))));
     const repeats = results.length - fresh.length;
 
+    const needsProfile =
+      input.isGrok && input.session_id && !readState(input.session_id).context;
+    const profileBlock = needsProfile ? formatProfile(response?.profile) : '';
+    if (needsProfile) {
+      const loaded =
+        (response?.profile?.static?.length || 0) +
+        (response?.profile?.dynamic?.length || 0);
+      writeState(input.session_id, 'context', {
+        status: 'ready',
+        memoryItemsLoaded: loaded,
+      });
+    }
+
     if (input.session_id) {
       const recalls = readState(input.session_id).search?.count || 0;
       writeState(input.session_id, 'search', {
@@ -155,7 +180,7 @@ async function main() {
       fresh: fresh.length,
     });
 
-    if (fresh.length === 0) {
+    if (fresh.length === 0 && !profileBlock) {
       writeOutput({ continue: true, suppressOutput: true });
       return;
     }
@@ -171,14 +196,24 @@ async function main() {
       }
     }
 
-    const label = repeats
-      ? `recalled ${fresh.length} new${gray(` · ${repeats} already in context`)}`
-      : `recalled ${fresh.length} ${fresh.length === 1 ? 'memory' : 'memories'}`;
+    const parts = [];
+    if (profileBlock) parts.push('profile loaded');
+    if (fresh.length > 0) {
+      parts.push(
+        repeats
+          ? `recalled ${fresh.length} new${gray(` · ${repeats} already in context`)}`
+          : `recalled ${fresh.length} ${fresh.length === 1 ? 'memory' : 'memories'}`,
+      );
+    }
+    const banner = `${BRAND} ${gray('·')} ${parts.join(gray(' · '))}`;
+    // Grok renders neither systemMessage nor (verified) any hook stdout text;
+    // stderr is the visibility channel there. Harmless under Claude Code.
+    if (input.isGrok) console.error(banner);
     writeOutput({
-      systemMessage: `${BRAND} ${gray('·')} ${label}`,
+      systemMessage: banner,
       hookSpecificOutput: {
         hookEventName: 'UserPromptSubmit',
-        additionalContext: formatRecall(fresh, containerTag),
+        additionalContext: formatRecall(fresh, containerTag, profileBlock),
       },
     });
   } catch (err) {

--- a/plugin/hooks/session-start.js
+++ b/plugin/hooks/session-start.js
@@ -11,6 +11,7 @@ const {
   debugLog,
 } = require('./lib/settings');
 const { BRAND, MARK, bold, gray } = require('./lib/colors');
+const { normalizeHookInput } = require('./lib/hook-input');
 const { readStdin, writeOutput } = require('./lib/stdin');
 const { startAuthFlow, AUTH_BASE_URL } = require('./lib/auth');
 const { getUserFriendlyError, isBenignError } = require('./lib/error-helpers');
@@ -135,7 +136,7 @@ async function main() {
   let sessionId;
 
   try {
-    const input = await readStdin();
+    const input = normalizeHookInput(await readStdin());
     sessionId = input.session_id;
     const cwd = input.cwd || process.cwd();
 

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -294,6 +294,98 @@ describe('recall-directive hook', () => {
   });
 });
 
+describe('grok compatibility', () => {
+  test('recall handles Grok payloads: camelCase keys, wrapped prompt, first-recall profile', async (t) => {
+    const { repo, home } = makeRepo(t);
+    mkdirSync(join(home, '.supermemory-claude'), { recursive: true });
+    writeFileSync(
+      join(home, '.supermemory-claude', 'credentials.json'),
+      JSON.stringify({ apiKey: 'sm_test_key_0123456789abcdef' }),
+    );
+    const stub = await startStubServer(t, (record, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          profile: { static: ['Prefers Bun'], dynamic: ['Working on Grok support'] },
+          searchResults: {
+            results: [{ memory: 'Chose Drizzle over Prisma', similarity: 0.82 }],
+          },
+        }),
+      );
+    });
+    const env = { HOME: home, USERPROFILE: home, SUPERMEMORY_API_URL: stub.url };
+    const grokInput = {
+      hookEventName: 'user_prompt_submit',
+      sessionId: 'grok-sess-1',
+      cwd: repo,
+      transcriptPath: '/tmp/nonexistent/updates.jsonl',
+      prompt: '<user_query>\ncontinue the database work from before\n</user_query>',
+    };
+
+    const first = await runHook('recall-directive.js', grokInput, env);
+    const output = JSON.parse(first.stdout);
+    const context = output.hookSpecificOutput.additionalContext;
+    assert.equal(
+      JSON.parse(stub.requests[0].body).q,
+      'continue the database work from before',
+    );
+    assert.match(context, /- ◪ Prefers Bun/);
+    assert.match(context, /- ◪ Working on Grok support/);
+    assert.match(context, /- ◪ Chose Drizzle over Prisma/);
+    assert.match(plain(output.systemMessage), /profile loaded · recalled 1 memory/);
+    assert.match(plain(first.stderr), /◪ supermemory/);
+
+    const second = JSON.parse((await runHook('recall-directive.js', grokInput, env)).stdout);
+    assert.equal(second.hookSpecificOutput, undefined);
+  });
+
+  test('capture reads Grok chat_history with a line-count cursor', async (t) => {
+    const { repo, home } = makeRepo(t);
+    mkdirSync(join(home, '.supermemory-claude'), { recursive: true });
+    writeFileSync(
+      join(home, '.supermemory-claude', 'credentials.json'),
+      JSON.stringify({ apiKey: 'sm_test_key_0123456789abcdef' }),
+    );
+    const sessionDir = makeTempDir(t, 'grok-session');
+    writeFileSync(join(sessionDir, 'updates.jsonl'), '');
+    writeFileSync(
+      join(sessionDir, 'chat_history.jsonl'),
+      [
+        JSON.stringify({ type: 'system', content: 'You are Grok.' }),
+        JSON.stringify({
+          type: 'user',
+          content: '<user_query>\nPlease fix the statusline symlink handling\n</user_query>',
+        }),
+        JSON.stringify({ type: 'reasoning', content: 'thinking...' }),
+        JSON.stringify({ type: 'assistant', content: 'Fixed: the symlink now re-points each session.' }),
+      ].join('\n'),
+    );
+    const stub = await startStubServer(t, (record, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ id: 'doc_g1' }));
+    });
+    const env = { HOME: home, USERPROFILE: home, SUPERMEMORY_API_URL: stub.url };
+    const grokInput = {
+      hookEventName: 'stop',
+      sessionId: 'grok-sess-2',
+      cwd: repo,
+      transcriptPath: join(sessionDir, 'updates.jsonl'),
+      reason: 'end_turn',
+    };
+
+    await runHook('capture.js', grokInput, env);
+    assert.equal(stub.requests.length, 1);
+    const body = JSON.parse(stub.requests[0].body);
+    assert.match(body.content, /fix the statusline symlink/);
+    assert.match(body.content, /re-points each session/);
+    assert.doesNotMatch(body.content, /<user_query>/);
+    assert.doesNotMatch(body.content, /thinking/);
+
+    await runHook('capture.js', grokInput, env);
+    assert.equal(stub.requests.length, 1, 'cursor should prevent recapture');
+  });
+});
+
 describe('stdin handling', () => {
   test('hooks finish even when stdin never emits end (issue #25)', async (t) => {
     const home = makeTempDir(t, 'stdin-home');


### PR DESCRIPTION
Makes the plugin work on Grok Build (xAI's CLI), which runs Claude-format plugins zero-config but with three host differences, all found by probing real Grok sessions on-machine:

1. **Payload shape**: Grok sends `sessionId`/`transcriptPath` (camelCase) and wraps prompts in `<user_query>` tags. Our hooks read snake_case — so capture bailed silently and dedup/state no-opped, while recall searched with tag-polluted queries. `lib/hook-input.js` normalizes both shapes for all four hooks.
2. **Transcript format**: Grok's `transcriptPath` points at ACP `updates.jsonl`; the conversation lives in the sibling `chat_history.jsonl` as `{type, content}` lines with no uuids. New adapter reads it with a line-count cursor (advanced only after a successful save, same as #101).
3. **No plugin SessionStart**: verified Grok never executes plugin SessionStart hooks, so the first recall of a session also injects the user profile — the `/v4/profile` response already carries it, zero extra API calls. The ◪ banner additionally mirrors to stderr since Grok renders no `systemMessage`.

Verified: hooks run on every Grok prompt/turn (32 executions in one real session), the recall hook produces profile + hits + banner against Grok-shaped payloads live, and 26/26 tests pass including two new Grok fixtures.

Remaining open question (needs one interactive Grok turn to verify): whether Grok consumes `hookSpecificOutput.additionalContext` from UserPromptSubmit. If it doesn't, plan B is writing recall into `.grok/rules/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)