### PR TITLE
feat: statusline auto-installs on first run (0.1.4)

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.1.3",
+  "version": "0.1.4",
   "updateCommand": "claude plugin update supermemory@supermemory-plugins"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-supermemory-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Claude code plugin by Supermemory AI",
   "private": true,
   "type": "commonjs",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supermemory",
   "displayName": "Supermemory",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Persistent memory across Claude Code sessions using Supermemory",
   "author": {
     "name": "Supermemory",

--- a/plugin/hooks/session-start.js
+++ b/plugin/hooks/session-start.js
@@ -31,6 +31,16 @@ const STATUSLINE_TIP_FILE = path.join(
   '.supermemory-claude',
   'statusline-tip-shown',
 );
+const STATUSLINE_INSTALLED_FILE = path.join(
+  os.homedir(),
+  '.supermemory-claude',
+  'statusline-installed',
+);
+const STATUSLINE_ENTRY = {
+  type: 'command',
+  command: 'node ~/.supermemory-claude/statusline-current',
+  refreshInterval: 1,
+};
 
 // The statusline setting needs one path that survives plugin updates; a
 // symlink re-pointed each session is that path — no code is ever copied.
@@ -46,20 +56,41 @@ function refreshStatuslineLink() {
   } catch {}
 }
 
-function statuslineTip() {
+// Installs the statusline into ~/.claude/settings.json on first run. The
+// sentinel file records that we installed once, so a user who deletes the
+// entry is never fought; a foreign statusLine is never overwritten.
+function installStatusline() {
+  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
   try {
-    if (fs.existsSync(STATUSLINE_TIP_FILE)) return null;
-    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    let settings = {};
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        return `${MARK} statusline not installed — ~/.claude/settings.json is unreadable: ${err.message}`;
+      }
+    }
     if (
       JSON.stringify(settings.statusLine || '').includes('statusline-current')
     ) {
       return null;
     }
-    fs.writeFileSync(STATUSLINE_TIP_FILE, new Date().toISOString());
-    return `${MARK} Supermemory status line available — add to ~/.claude/settings.json: "statusLine": {"type": "command", "command": "node ~/.supermemory-claude/statusline-current", "refreshInterval": 1} (refreshInterval keeps it animating while idle).`;
-  } catch {
-    return null;
+    if (settings.statusLine) {
+      if (fs.existsSync(STATUSLINE_TIP_FILE)) return null;
+      fs.mkdirSync(path.dirname(STATUSLINE_TIP_FILE), { recursive: true });
+      fs.writeFileSync(STATUSLINE_TIP_FILE, new Date().toISOString());
+      return `${MARK} Supermemory status line available — you already have a "statusLine" in ~/.claude/settings.json; replace it with ${JSON.stringify(STATUSLINE_ENTRY)} to switch.`;
+    }
+    if (fs.existsSync(STATUSLINE_INSTALLED_FILE)) return null;
+    settings.statusLine = STATUSLINE_ENTRY;
+    const tmp = `${settingsPath}.supermemory-tmp`;
+    fs.writeFileSync(tmp, `${JSON.stringify(settings, null, 2)}\n`);
+    fs.renameSync(tmp, settingsPath);
+    fs.mkdirSync(path.dirname(STATUSLINE_INSTALLED_FILE), { recursive: true });
+    fs.writeFileSync(STATUSLINE_INSTALLED_FILE, new Date().toISOString());
+    return `${MARK} statusline installed — it appears the next time Claude Code starts (delete "statusLine" from ~/.claude/settings.json to turn it off).`;
+  } catch (err) {
+    return `${MARK} statusline install failed: ${err.message}`;
   }
 }
 
@@ -212,7 +243,7 @@ Memories will be saved as you work.
           .filter(Boolean)
           .join(gray(' · ')) || null,
         markTip(),
-        statuslineTip(),
+        installStatusline(),
       ],
     );
   } catch (err) {


### PR DESCRIPTION
The statusline was never getting configured: the old flow emitted a one-time tip as a SessionStart systemMessage — trivially missed, and a sentinel file guaranteed it never repeated. Users ended up with no statusline and no path back.

SessionStart now installs it automatically:

- Writes `statusLine` into `~/.claude/settings.json` (atomic temp-file + rename) when none exists, pointing at the version-independent `~/.supermemory-claude/statusline-current` symlink
- **Never overwrites** a foreign `statusLine` — one-time suggestion instead
- **Never fights removal** — a `statusline-installed` sentinel means deleting the entry sticks
- Unparseable settings.json → visible "not installed because X" message, file untouched

Verified in a sandboxed $HOME: fresh install, idempotent re-run, user-deleted entry stays deleted, foreign statusline untouched, corrupt settings surfaced loudly.

Also bumps 0.1.3 → 0.1.4 (package.json, plugin.json, latest.json) — supersedes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Z6UdMd9aUZUFdqBDEuVTB