### PR TITLE
Fail open with 3s network cap on all hooks; async capture; token count in recall banner

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Supermemory: persistent memory for Claude Code",
+  "description": "Supermemory: persistent memory for Claude Code. Injection hooks (SessionStart, UserPromptSubmit, PreToolUse) must stay synchronous — async hooks' output is discarded, which would silently kill context injection and auto-approval. They fail open instead: every network call is capped at 3s and the hook timeout is a backstop, so a dead network never stalls the session. Capture has no output anyone reads, so it runs async.",
   "hooks": {
     "SessionStart": [
       {
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/recall-directive.js\"",
-            "timeout": 10
+            "timeout": 5
           }
         ]
       }
@@ -30,7 +30,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/recall-approve.js\"",
-            "timeout": 10
+            "timeout": 5
           }
         ]
       }
@@ -41,6 +41,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/capture.js\"",
+            "async": true,
             "timeout": 30
           }
         ]

--- a/plugin/hooks/lib/api.js
+++ b/plugin/hooks/lib/api.js
@@ -20,7 +20,12 @@ SKIP:
 - Transient command output and low-value implementation chatter
 - Granular details that do not help future work`;
 
-async function post(baseUrl, apiKey, path, body, timeoutMs = 15000) {
+// Hooks sit between the user and Claude — a slow or dead network must never
+// hold the session hostage, so every request is capped hard at 3s and callers
+// treat failure as "no memory this time", not a blocker.
+const REQUEST_TIMEOUT_MS = 3000;
+
+async function post(baseUrl, apiKey, path, body, timeoutMs = REQUEST_TIMEOUT_MS) {
   const response = await fetch(`${baseUrl.replace(/\/+$/, '')}${path}`, {
     method: 'POST',
     headers: {

--- a/plugin/hooks/lib/error-helpers.js
+++ b/plugin/hooks/lib/error-helpers.js
@@ -15,6 +15,13 @@
 function getUserFriendlyError(err) {
   const status = err?.status;
 
+  if (
+    err?.name === 'TimeoutError' ||
+    err?.name === 'AbortError' ||
+    err?.message === 'fetch failed'
+  ) {
+    return 'Supermemory unreachable (network) — continuing without memory.';
+  }
   if (status === 400) {
     return 'Bad request \u2014 your API key or request format may be invalid. Check your key at https://console.supermemory.ai';
   }

--- a/plugin/hooks/lib/statusline-state.js
+++ b/plugin/hooks/lib/statusline-state.js
@@ -89,7 +89,11 @@ function sanitizeEvent(event, data) {
     return { status, count: normalizeCount(data.count) };
   }
 
-  return { results: normalizeCount(data.results), count: normalizeCount(data.count) };
+  return {
+    results: normalizeCount(data.results),
+    count: normalizeCount(data.count),
+    memories: normalizeCount(data.memories),
+  };
 }
 
 function writeState(sessionId, event, data = {}, options = {}) {

--- a/plugin/hooks/recall-approve.js
+++ b/plugin/hooks/recall-approve.js
@@ -33,8 +33,12 @@ async function main() {
           ? input.tool_input.query
           : null;
       if (tool === 'search_memory') {
-        const recalls = readState(input.session_id).search?.count || 0;
-        writeState(input.session_id, 'search', { results: 0, count: recalls + 1 });
+        const prev = readState(input.session_id).search || {};
+        writeState(input.session_id, 'search', {
+          results: 0,
+          count: (prev.count || 0) + 1,
+          memories: prev.memories || 0,
+        });
       }
       writeOutput({
         systemMessage: query

--- a/plugin/hooks/recall-directive.js
+++ b/plugin/hooks/recall-directive.js
@@ -143,10 +143,11 @@ async function main() {
     const repeats = results.length - fresh.length;
 
     if (input.session_id) {
-      const recalls = readState(input.session_id).search?.count || 0;
+      const prev = readState(input.session_id).search || {};
       writeState(input.session_id, 'search', {
         results: fresh.length,
-        count: recalls + 1,
+        count: (prev.count || 0) + 1,
+        memories: (prev.memories || 0) + fresh.length,
       });
     }
 

--- a/plugin/hooks/recall-directive.js
+++ b/plugin/hooks/recall-directive.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const { getProfile } = require('./lib/api');
 const { BRAND, gray, red } = require('./lib/colors');
 const { getContainerTag } = require('./lib/container-tag');
+const { getUserFriendlyError } = require('./lib/error-helpers');
 const { loadProjectConfig } = require('./lib/project-config');
 const {
   loadSettings,
@@ -30,7 +31,7 @@ const MAX_QUERY_LENGTH = 500;
 const MAX_RESULTS = 5;
 const MAX_RESULT_CHARS = 300;
 const MIN_SIMILARITY = 0.55;
-const SEARCH_TIMEOUT_MS = 4000;
+const SEARCH_TIMEOUT_MS = 3000;
 const MAX_SEEN_HASHES = 500;
 
 function shouldSkip(prompt) {
@@ -171,20 +172,23 @@ async function main() {
       }
     }
 
+    const context = formatRecall(fresh, containerTag);
+    // ~4 chars/token: close enough to show what the injection costs.
+    const tok = gray(`(${Math.round(context.length / 4)} tok)`);
     const label = repeats
-      ? `recalled ${fresh.length} new${gray(` · ${repeats} already in context`)}`
-      : `recalled ${fresh.length} ${fresh.length === 1 ? 'memory' : 'memories'}`;
+      ? `recalled ${fresh.length} new ${tok}${gray(` · ${repeats} already in context`)}`
+      : `recalled ${fresh.length} ${fresh.length === 1 ? 'memory' : 'memories'} ${tok}`;
     writeOutput({
       systemMessage: `${BRAND} ${gray('·')} ${label}`,
       hookSpecificOutput: {
         hookEventName: 'UserPromptSubmit',
-        additionalContext: formatRecall(fresh, containerTag),
+        additionalContext: context,
       },
     });
   } catch (err) {
     debugLog(settings, 'Recall directive error', { error: err.message });
     writeOutput({
-      systemMessage: `${BRAND} ${gray('·')} ${red(`recall failed: ${err.message.slice(0, 80)}`)}`,
+      systemMessage: `${BRAND} ${gray('·')} ${red(`recall failed: ${getUserFriendlyError(err).slice(0, 80)}`)}`,
       continue: true,
       suppressOutput: true,
     });

--- a/plugin/hooks/session-start.js
+++ b/plugin/hooks/session-start.js
@@ -13,7 +13,7 @@ const {
 const { BRAND, MARK, bold, gray } = require('./lib/colors');
 const { readStdin, writeOutput } = require('./lib/stdin');
 const { startAuthFlow, AUTH_BASE_URL } = require('./lib/auth');
-const { getUserFriendlyError, isBenignError } = require('./lib/error-helpers');
+const { getUserFriendlyError } = require('./lib/error-helpers');
 const { LAST_SESSION_FILE } = require('./lib/last-session');
 const {
   pruneState,
@@ -207,7 +207,9 @@ Or set the SUPERMEMORY_CC_API_KEY environment variable.
     try {
       profileResult = await getProfile(baseUrl, apiKey, containerTag, projectName);
     } catch (err) {
-      if (!isBenignError(err)) apiError = getUserFriendlyError(err);
+      // Fail open, but never silently: a network failure must not be dressed
+      // up as "this project has no memories". Only 404 means genuinely empty.
+      if (err?.status !== 404) apiError = getUserFriendlyError(err);
       debugLog(settings, 'Profile fetch failed', { error: err.message });
     }
 
@@ -234,10 +236,14 @@ Or set the SUPERMEMORY_CC_API_KEY environment variable.
     output(
       (apiError ? `<supermemory-status>\n${apiError}\n</supermemory-status>\n` : '') +
         (context ||
-          `<supermemory-context>
+          (apiError
+            ? `<supermemory-context>
+Memory could not be loaded this session — do not assume this project has no memories.
+</supermemory-context>`
+            : `<supermemory-context>
 No previous memories found for this project (container: ${containerTag}).
 Memories will be saved as you work.
-</supermemory-context>`),
+</supermemory-context>`)),
       [
         [memoryNotice, welcomeBackNotice(containerTag)]
           .filter(Boolean)

--- a/plugin/statusline.js
+++ b/plugin/statusline.js
@@ -136,7 +136,13 @@ function getStatus(state, now) {
     savedAt = capture.updatedAt;
   }
   if (search?.count > 0 && search.updatedAt >= generation) {
-    parts.push(`${search.count} ${search.count === 1 ? 'recall' : 'recalls'}`);
+    // Memories in context beats event counts; MCP-tool searches inject
+    // nothing trackable, so those sessions fall back to the recall tally.
+    parts.push(
+      search.memories > 0
+        ? `${search.memories} recalled`
+        : `${search.count} ${search.count === 1 ? 'recall' : 'recalls'}`,
+    );
     recalledAt = search.updatedAt;
   }
 

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -218,6 +218,7 @@ describe('recall-directive hook', () => {
     });
     assert.equal(state.search.count, 1);
     assert.equal(state.search.results, 4);
+    assert.equal(state.search.memories, 4);
   });
 
   test('skips trivial prompts and slash commands without an API call', async (t) => {
@@ -275,6 +276,7 @@ describe('recall-directive hook', () => {
     });
     assert.equal(state.search.count, 3);
     assert.equal(state.search.results, 1);
+    assert.equal(state.search.memories, 3);
   });
 
   test('a configured recallDirective restores advisory mode verbatim', async (t) => {
@@ -664,6 +666,17 @@ describe('statusline rendering', () => {
         now + 20,
       ),
       '3 loaded · 1 recall',
+    );
+    // With injected memories tracked, the tally counts memories, not events.
+    assert.equal(
+      getStatusLabel(
+        {
+          context,
+          search: { results: 4, count: 2, memories: 9, updatedAt: now + 12 },
+        },
+        now + 20,
+      ),
+      '3 loaded · 9 recalled',
     );
     assert.equal(
       renderStatusline({ context }, { now, color: false }),

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -206,7 +206,7 @@ describe('recall-directive hook', () => {
     assert.match(context, /- ◪ Migration plan — Use expand-contract migrations/);
     assert.doesNotMatch(context, /irrelevant low-similarity hit/);
     assert.match(context, /repo_example_project__/);
-    assert.match(plain(output.systemMessage), /^◪ supermemory · recalled \d+ memories$/);
+    assert.match(plain(output.systemMessage), /^◪ supermemory · recalled \d+ memories \(\d+ tok\)$/);
     assert.equal(stub.requests[0].url, '/v4/profile');
     assert.equal(
       JSON.parse(stub.requests[0].body).q,
@@ -258,7 +258,7 @@ describe('recall-directive hook', () => {
     const input = { session_id: 's-dedup', cwd: repo, prompt: 'continue the database work' };
 
     const first = JSON.parse((await runHook('recall-directive.js', input, env)).stdout);
-    assert.equal(plain(first.systemMessage), '◪ supermemory · recalled 2 memories');
+    assert.match(plain(first.systemMessage), /^◪ supermemory · recalled 2 memories \(\d+ tok\)$/);
 
     const second = JSON.parse((await runHook('recall-directive.js', input, env)).stdout);
     assert.equal(second.systemMessage, undefined);
@@ -266,7 +266,7 @@ describe('recall-directive hook', () => {
 
     hits = [...hits, { memory: 'New fact about migrations', similarity: 0.8 }];
     const third = JSON.parse((await runHook('recall-directive.js', input, env)).stdout);
-    assert.equal(plain(third.systemMessage), '◪ supermemory · recalled 1 new · 2 already in context');
+    assert.match(plain(third.systemMessage), /^◪ supermemory · recalled 1 new \(\d+ tok\) · 2 already in context$/);
     assert.match(third.hookSpecificOutput.additionalContext, /New fact about migrations/);
     assert.doesNotMatch(third.hookSpecificOutput.additionalContext, /Chose Drizzle over Prisma/);
 


### PR DESCRIPTION
## What

Hooks must never hold the session hostage on a bad network, and the recall banner now shows what the injection costs.

### Fail open + 3s cap
- Every hook API call is hard-capped at **3s** (`REQUEST_TIMEOUT_MS` in `lib/api.js`; was 15s default, 4s for recall search).
- Verified live: connection refused fails open in ~0.1s; a hanging server is cut at 3.1s. Both continue the session with a visible error banner.
- Network failures map to a clean "Supermemory unreachable (network) — continuing without memory" instead of raw fetch errors (`TimeoutError`/`AbortError`/`fetch failed` branch in `error-helpers.js`).
- **Honesty fix**: session-start no longer injects "No previous memories found for this project" when the profile fetch *failed* — that disguised an outage as an empty container and misinformed the model. Only a 404 means empty; failures inject "memory could not be loaded — do not assume this project has no memories" and mark the statusline state as `error`.

### Async
- `capture.js` (Stop) now runs with `"async": true` — pure fire-and-forget save, output unused, user gets the prompt back immediately.
- SessionStart / UserPromptSubmit / PreToolUse **stay synchronous by necessity**: per the hooks docs, an async hook's stdout is discarded entirely — `additionalContext`, `permissionDecision`, and `systemMessage` would all be silently dropped, killing recall injection and read-only auto-approval. The 3s cap + fail-open is what bounds them instead. Backstop hook timeouts tightened 10s → 5s (SessionStart stays 30s only for the interactive first-run auth flow, which needs 25s).
- Deliberately untouched: `mcp-proxy.js` stays at 30s — it serves explicit MCP tool calls, not hooks, and already fails open per-message via JSON-RPC errors.

### Recall banner token count
- `◪ supermemory · recalled 5 memories (32 tok)` — estimates the injected context block at ~4 chars/token. Partial-overlap mode: `recalled 1 new (18 tok) · 2 already in context`.

## Testing
- All 24 unit tests pass (`node --test test/unit.mjs`); banner assertions updated for the token suffix.
- Live fail-open simulation against dead/hanging endpoints (timings above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsBZgW6vDm8GEcy9ML3dT