### PR TITLE
chore: bump to 0.1.5

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "updateCommand": "claude plugin update supermemory@supermemory-plugins"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-supermemory-dev",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Claude code plugin by Supermemory AI",
   "private": true,
   "type": "commonjs",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supermemory",
   "displayName": "Supermemory",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Persistent memory across Claude Code sessions using Supermemory",
   "author": {
     "name": "Supermemory",


### PR DESCRIPTION
Version bump for the release containing #108 (fail-open + 3s cap + async capture + recall token count + statusline recalled-memories tally). Updates package.json, latest.json, and plugin.json together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsBZgW6vDm8GEcy9ML3dT