### PR TITLE
Use short Supermemory save and search skill names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ export SUPERMEMORY_CC_API_KEY="sm_..."
 ## How It Works
 
 - **Reasoned recall** — Before each turn, Claude decides whether recalling memory would actually help your current message, and only searches when it's worth it — every turn, once in a while, or not at all. The search runs automatically (no permission prompt), just like auto-capture. Searching only when needed also keeps more usage on your plan
-- **supermemory-search** — Ask about past work or previous sessions, Claude searches your memories
-- **supermemory-save** — Ask to save something important, Claude saves it for the team
+- **`/supermemory:search`** — Search past work, previous sessions, and saved project context
+- **`/supermemory:save`** — Save important project knowledge for future sessions
 
 ### Shared Agents memory
 
@@ -68,6 +68,8 @@ write destination. Older personal/user overrides remain in the legacy read set.
 
 | Command                              | Description                              |
 | ------------------------------------ | ---------------------------------------- |
+| `/supermemory:save`           | Save important project knowledge         |
+| `/supermemory:search`         | Search saved project context              |
 | `/supermemory:index`          | Index codebase architecture and patterns |
 | `/supermemory:project-config` | Configure project-level settings         |
 | `/supermemory:logout`         | Clear saved credentials                  |

--- a/plugin/skills/save/SKILL.md
+++ b/plugin/skills/save/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: save
+description: Save important project knowledge to Supermemory. Use when the user wants to preserve an architectural decision, significant bug fix, design pattern, or implementation detail for future sessions.
+argument-hint: [what to remember]
+allowed-tools: mcp__supermemory__add_memory mcp__plugin_supermemory_supermemory__add_memory mcp__claude_ai_supermemory__add_memory
+---
+
+# Save to Supermemory
+
+Save the project knowledge the user wants to preserve.
+
+1. Use `$ARGUMENTS` when it contains the information to save. Otherwise, infer the requested memory from the immediately preceding conversation.
+2. Keep the memory focused and self-contained. Include relevant decisions, reasoning, and file paths, but never include secrets.
+3. Call the available Supermemory `add_memory` tool with `action: "save"`.
+4. Use the current project's `containerTag` from `<supermemory-context>` so the memory remains attached to this repository. If no project container is available, omit `containerTag` and use the active Supermemory space.
+5. Report the tool result. Never claim the memory was saved unless the tool confirms success.

--- a/plugin/skills/search/SKILL.md
+++ b/plugin/skills/search/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: search
+description: Search Supermemory for past project work, previous sessions, decisions, implementation details, and other saved context.
+argument-hint: [memory query]
+allowed-tools: mcp__supermemory__search_memory mcp__plugin_supermemory_supermemory__search_memory mcp__claude_ai_supermemory__search_memory
+---
+
+# Search Supermemory
+
+Search saved project knowledge for the context the user needs.
+
+1. Use `$ARGUMENTS` as the query. If it is empty, derive a concise query from the user's immediately preceding request.
+2. Call the available Supermemory `search_memory` tool.
+3. Use the current project's `containerTag` from `<supermemory-context>` so results stay scoped to this repository. If no project container is available, omit `containerTag` and search the active Supermemory space.
+4. Present the relevant results clearly. Say when nothing relevant was found instead of inventing an answer.


### PR DESCRIPTION
## Summary

- add MCP-backed plugin skills named `save` and `search`
- expose the commands as `/supermemory:save` and `/supermemory:search`
- keep saves and searches scoped to the current repository container when available
- update the README with the exact command names

## Why

Claude Code automatically prefixes plugin skills with the plugin namespace. Naming a skill `supermemory-save` therefore renders it as `/supermemory:supermemory-save`. Using the short skill names avoids repeating the namespace and works with the current hosted MCP architecture.

## Validation

- `claude plugin validate plugin` (passes; reports the existing `privacyPolicy` manifest warning)
- static path/frontmatter check confirms both exact command names
- `git diff --check`
- repository Biome check

The full unit suite was not run because it launches local HTTP stub servers; no servers were started.