### PR TITLE
docs: point API key setup at console.supermemory.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Your agent remembers what you worked on - across sessions, across projects.
 > /plugin uninstall claude-supermemory@supermemory-plugins
 > ```
 
-Set your API key (get one at [app.supermemory.ai](https://app.supermemory.ai)):
+Set your API key (get one at [console.supermemory.ai](https://console.supermemory.ai)):
 
 ```bash
 export SUPERMEMORY_CC_API_KEY="sm_..."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Update the README API-key setup link from `app.supermemory.ai` to `https://console.supermemory.ai`, matching where the current login flow actually lives.

## Why

QA flagged that the README still tells users to get an API key at `app.supermemory.ai`, but the 0.1.6 login authenticates through the console. Verified against the source:

- `plugin/.claude-plugin/plugin.json` → version `0.1.6`
- `plugin/hooks/lib/auth.js` → `AUTH_BASE_URL` defaults to `https://console.supermemory.ai/auth/connect`
- `plugin/hooks/lib/error-helpers.js` → auth/bad-request errors already direct users to `https://console.supermemory.ai`

`app.supermemory.ai` in `README.md` was the only remaining user-facing reference still pointing at the old host; all other domain references (`api.`, `mcp.`, `console.`, `supermemory.ai`) are already correct.

## Change

```diff
-Set your API key (get one at [app.supermemory.ai](https://app.supermemory.ai)):
+Set your API key (get one at [console.supermemory.ai](https://console.supermemory.ai)):
```

Docs-only. Nothing ships until merge + deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e882e9c-29f1-4475-890e-d92e246c982f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e882e9c-29f1-4475-890e-d92e246c982f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

