### PR TITLE
restore 4s recall and silence timeouts

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Supermemory: persistent memory for Claude Code. Injection hooks (SessionStart, UserPromptSubmit, PreToolUse) must stay synchronous — async hooks' output is discarded, which would silently kill context injection and auto-approval. They fail open instead: every network call is capped at 3s and the hook timeout is a backstop, so a dead network never stalls the session. Capture has no output anyone reads, so it runs async.",
+  "description": "Supermemory hooks: SessionStart loads project memories; UserPromptSubmit recalls memories relevant to the prompt; PreToolUse approves read-only Supermemory tool calls; Stop saves new conversation content to memory.",
   "hooks": {
     "SessionStart": [
       {

--- a/plugin/hooks/lib/api.js
+++ b/plugin/hooks/lib/api.js
@@ -21,8 +21,8 @@ SKIP:
 - Granular details that do not help future work`;
 
 // Hooks sit between the user and Claude — a slow or dead network must never
-// hold the session hostage, so every request is capped hard at 3s and callers
-// treat failure as "no memory this time", not a blocker.
+// hold the session hostage. Requests default to 3s; prompt recall allows 4s.
+// Callers treat failure as "no memory this time", not a blocker.
 const REQUEST_TIMEOUT_MS = 3000;
 
 async function post(baseUrl, apiKey, path, body, timeoutMs = REQUEST_TIMEOUT_MS) {

--- a/plugin/hooks/recall-directive.js
+++ b/plugin/hooks/recall-directive.js
@@ -31,7 +31,7 @@ const MAX_QUERY_LENGTH = 500;
 const MAX_RESULTS = 5;
 const MAX_RESULT_CHARS = 300;
 const MIN_SIMILARITY = 0.55;
-const SEARCH_TIMEOUT_MS = 3000;
+const SEARCH_TIMEOUT_MS = 4000;
 const MAX_SEEN_HASHES = 500;
 
 function shouldSkip(prompt) {
@@ -188,6 +188,11 @@ async function main() {
     });
   } catch (err) {
     debugLog(settings, 'Recall directive error', { error: err.message });
+    // A slow recall should not interrupt every prompt with an error banner.
+    if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
+      writeOutput({ continue: true, suppressOutput: true });
+      return;
+    }
     writeOutput({
       systemMessage: `${BRAND} ${gray('·')} ${red(`recall failed: ${getUserFriendlyError(err).slice(0, 80)}`)}`,
       continue: true,


### PR DESCRIPTION
Restores the 4s prompt recall timeout and skips timed-out recall without an error banner. The hooks description now states what each hook does.

Verified before and after in real Claude Code sessions against a local HTTP server: a 3.5s response now reaches Claude, and a hanging recall stops quietly after 4s. All 24 existing tests pass.

Related to #119.
